### PR TITLE
Homepage Read Docs link now links to user docs site

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ title: Go - Continuous Delivery software
     </span>
     <h5>Or you can, </h5>
     <ul class="other-options">
-        <li><a target="_blank" href="https://github.com/gocd/documentation"><i class='icon-doc-text-inv'></i>Read Documentation</a>
+        <li><a target="_blank" href="http://www.go.cd/documentation/user/current/"><i class='icon-doc-text-inv'></i>Read Documentation</a>
         </li>
         <li>
             <a target="_blank" href="https://groups.google.com/forum/#!forum/go-cd"> <i class='icon-mail-alt'></i>Join the mailing list</a>


### PR DESCRIPTION
I thought it would be useful in the main Read Documentation link on the Go homepage pointed at the actual site rather than the GitHub documentation project, as it is easier to use and the proper link is hard to find otherwise.