### PR TITLE
Adding Slack build notifier plugin to the list

### DIFF
--- a/community/plugins.html
+++ b/community/plugins.html
@@ -305,6 +305,8 @@ Below is the listing of bundled as well as other available plugins contributed b
 
 </ul>
 
+<div style="clear:both"></div>
+
 <h4>Enterprise extensions (1)</h4>
 
 <ul class="plugins">

--- a/community/plugins.html
+++ b/community/plugins.html
@@ -287,6 +287,24 @@ Below is the listing of bundled as well as other available plugins contributed b
 
 <div style="clear:both"></div>
 
+<h4>Notification plugins (1)</h4>
+
+<ul class="plugins">
+  <li class="grid-3">
+      <h5>Slack Build Notifier</h5>
+      <div class="more_details">
+        Plugin to get build notifications on Slack. <a href="https://github.com/ashwanthkumar/gocd-slack-build-notifier">Read more</a>
+      </div>
+      <div>by <a href="https://github.com/ashwanthkumar">Ashwanth Kumar</a>
+      </div>
+      <div class="actions">
+        <a  href="https://github.com/ashwanthkumar/gocd-slack-build-notifier/releases"><i class='icon-download'></i>Download</a> -
+        <a href="https://github.com/ashwanthkumar/gocd-slack-build-notifier"><i class='icon-code'></i>Source</a>
+      </div>
+  </li>
+
+</ul>
+
 <h4>Enterprise extensions (1)</h4>
 
 <ul class="plugins">


### PR DESCRIPTION
Created a Notification plugins section, and added slack build notifier plugin to the list.