### PR TITLE
Subscribe to updates link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ navigation:
   first-level:
     - text: Why Go?
       url: /learn-more/why-go.html
+    - text: Subscribe to Updates
+      url: /subscribe.html
     - text: Help Doc
       url: http://www.go.cd/documentation/user/current/
       target: _blank

--- a/css/main.css
+++ b/css/main.css
@@ -922,3 +922,15 @@ body.blog {
 .version figure.extra_small_image img {
     width: 50%; margin-left: 10%;
 }
+
+/**********************************/
+/*  Subscribe                     */
+/**********************************/
+
+.subscribe {
+    border-bottom: 1px solid #efefef;
+    padding-top: 10px;
+    margin-bottom: 30px;
+    padding-bottom: 10px;
+    text-align: left;
+}

--- a/download/index.html
+++ b/download/index.html
@@ -15,6 +15,8 @@ meta_tag_keywords: continuous deployment software, continuous integration tools,
 
 <p>If you need help downloading, installing or using Go please join the <a href="https://groups.google.com/forum/#!forum/go-cd">Go Users Google Group</a>. ThoughtWorks also provides commercial help for Go. They can be reached at <a href="mailto:support@thoughtworks.com">support@thoughtworks.com</a>.</p>
 
+<p class="highlight"> New! <a href="/subscribe.html">Subscribe to updates</a> on new Go CD releases and more</p>
+
 <p class="highlight"><img alt="Warning" src="/images/icon-warning-small.gif"/>  OpenJDK users might face an issue with upload of compressed artifacts on Go 14.3.0 and later versions.<a href="/2014/11/14/Go_14_3_issue_with_uploading_compressed_artifacts.html">Read more</a> for details.</p>
 
 <h4>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@ title: Go - Continuous Delivery software
         <li>
             <a target="_blank" href="https://groups.google.com/forum/#!forum/go-cd"> <i class='icon-mail-alt'></i>Join the mailing list</a>
         </li>
+        <li>
+            <a href="/subscribe.html"> <i class='icon-mail-alt'></i>Get Go CD updates</a>
+        </li>
         <li><a target="_blank" href="https://github.com/gocd/gocd/issues/new"><i class='icon-github-squared'></i>Create issue</a>
         </li>
     </ul>

--- a/subscribe.html
+++ b/subscribe.html
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Subscribe to GO CD Updates
+title_tag: Subscribe to Go CD Updates
+meta_tag_description: GO Continuous Delivery is a software development discipline where you automate all steps of building, testing, deploying and releasing software at anytime
+meta_tag_keywords: continuous delivery, software development, blog, testing, deploying, go
+---
+
+<div class="subscribe full-width">
+    <div class="grid-7">
+        <p>If you'd like to receive information about Go CD but don't want the volume of the mailing lists this is the place
+            for you. From time to time ThoughtWorks (Go CD's primary sponsor) will send out updates. This will include information
+            such as...
+        </p>
+
+        <ul>
+            <li> New supported release announcements </li>
+            <li> Any security related announcements </li>
+            <li> Learning resources</li>
+        </ul>
+        <br>
+        <p>The volume will be extremely low, focusing on information we believe will be a real value to people using Go CD.</p>
+    </div>
+    <div class="grid-5">
+        <script src="//app-e.marketo.com/js/forms2/js/forms2.min.js"></script>
+        <form id="mktoForm_3085"></form>
+        <script>MktoForms2.loadForm("//app-e.marketo.com", "199-QDE-291", 3085);</script>
+    </div>
+</div>
+


### PR DESCRIPTION
We've heard quite often that people using Go don't know when a new release comes out. Since we don't require any information to download, there hasn't been a way other than social networks to share this information. 

We've created a program in our marketing system that will allow us to update people on important news about Go. People subscribing for these updates will not be added to other marketing programs. 

We're still not requiring personal information to download, but now people will have a way to subscribe to updates if they want them.