### PR TITLE
Fixing links to roadmap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ navigation:
     - text: Contribution Guide
       url: /contribute/contribution-guide.html
     - text: Roadmap
-      url: https://github.com/gocd/gocd/issues/1076
+      url: https://github.com/gocd/gocd/milestones?direction=desc&sort=completeness&state=open
       target: _blank
     - text: CLA
       url: /contribute/cla.html

--- a/contribute/index.html
+++ b/contribute/index.html
@@ -64,7 +64,7 @@ meta_tag_keywords: open source software, contribute to open source, agile contin
             <li>Tech Debts</li>
         </ul>
     </p>
-    <a href="/contribute/roadmap.html">Read more</a>
+    <a href="https://github.com/gocd/gocd/milestones?direction=desc&sort=completeness&state=open" target="_blank">Read more</a>
 </div>
 <div class="grid-4 code-contribution-process">
     <h4>Code contribution process</h4>


### PR DESCRIPTION
One was pointing to the previous release and another to a non-existent page
This now lands on the [milestone](https://github.com/gocd/gocd/milestones?direction=desc&sort=completeness&state=open) page so people could have a look at all open milestones sorted based on the completion status