### PR TITLE
Removing 15.2 release announcement as we are nearing 15.3 release

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -44,8 +44,6 @@
             </div>
         </div>
 
-        {% include releaseAnnouncement.html %}
-
         <div class="container-12">
             {{ content }}
         </div>


### PR DESCRIPTION
Do we need this banner till we make the next release? I think we should have run this for a while and retired it.

Please feel free to take a call on this.