### PR TITLE
Removing overflow on the div to fix problem on smaller screens

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -765,7 +765,6 @@ body.blog {
     width: inherit;
 }
 .release-announce-holder{
-    overflow: auto;
     text-align:center;
     color: white;
     padding: 30px;


### PR DESCRIPTION
This fixed the banner problem on safari. Not sure why the overflow was set.