### PR TITLE
Improve Plugins Grid formatting

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -274,11 +274,11 @@ body.blog {
 }
 .plugins .more_details {
     font-size: 10px;
-}
-.plugins .more_details {
     margin-bottom: 10px;
+    height: 30px;
 }
 .plugins h5 {
+    height: 70px;
     margin-top: 0;
     padding-right: 15px;
     padding-top: 0;


### PR DESCRIPTION
2-line titles on plugins or single-line descriptions caused the plugin grid to fall out of of square.

Before:

![repository plugins task plugins notification plugins scm plugins go cd-zxl3c](https://cloud.githubusercontent.com/assets/76716/12329671/04fa3d70-baa7-11e5-8d30-9bcc210e2cf4.png)

After:

![repository plugins task plugins notification plugins scm plugins go cd-25xj8](https://cloud.githubusercontent.com/assets/76716/12329682/1619c12a-baa7-11e5-8620-8fdafd58f917.png)

We have two remaining issues though:

1. two-line "By"-lines
2. the "Contribute" square

![repository plugins task plugins notification plugins scm plugins go cd-hxslb](https://cloud.githubusercontent.com/assets/76716/12329733/4842778c-baa7-11e5-8264-7af25f4e6aa8.png)


