### PR TITLE
fix the broken grid system

### DIFF
--- a/css/responsive.css
+++ b/css/responsive.css
@@ -15,6 +15,7 @@
  @media(max-width: 960px) {
     .navigation {
         margin-top: 0;
+        padding-left: 0;
         float: left;
     }
     .navigation li {

--- a/css/rwdgrid.css
+++ b/css/rwdgrid.css
@@ -405,6 +405,7 @@ table {
 
 .grid-1, .grid-2, .grid-3, .grid-4, .grid-5, .grid-6, .grid-7, .grid-8, .grid-9, .grid-10, .grid-11, .grid-12, .grid-13, .grid-14, .grid-15, .grid-16 {
 	display:inline;
+        float: left;
 	margin-left: 10px;
 	margin-right: 10px;
 }


### PR DESCRIPTION
Here is an accidental change (a1b829ad34753ed814fc7c6f2b5700ecd2481701) to css grid library 'rwdgrid.css', which cause couple place using grid broken.  For example: https://www.go.cd/contribute/contribution-guide.html.

This PR revert that change.  It also reduced the navigation bar padding to compensate the grid margin added while grid system is really working