### PR TITLE
Add journey-app integeration to track vistor actions anonymously

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -3,3 +3,6 @@
 document.write(unescape("%3Cscript src='//munchkin.marketo.net/munchkin.js' type='text/javascript'%3E%3C/script%3E"));
 </script>
 <script>Munchkin.init('199-QDE-291');</script>
+<script type="text/javascript">
+!function(){var t=window.jtr=window.jtr||[];if(!t.initialize){if(t.invoked)return void(window.console&&console.error&&console.error("Journey tracking snippet included twice."));t.invoked=!0,t.methods=["page","identify","userTraits","experimentGroup","track","trackInteraction","noConflict"],t.factory=function(e){return function(){var n=Array.prototype.slice.call(arguments);return n.unshift(e),t.push(n),t}};for(var e=0;e<t.methods.length;e++){var n=t.methods[e];t[n]=t.factory(n)}t.load=function(t){var e=document.documentElement;e.setAttribute("data-jtr-device-token",t);e.setAttribute("data-jtr-events-url", "https://event-stream.journey-app.io/events");var n=document.createElement("script");n.type="text/javascript",n.async=!0,n.src="https://cdn.journey-app.io/v1.0.3/journey-tracker.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(n,r)},t.load({% if jekyll.environment == 'production' %}"j.eca3f1b7-dbb4-4594-bade-9a8eb66ffe2a"{% else %}"j.c0efee8e-f6bb-4d90-a66b-cd69d6fc26a2"{% endif %}),t.page()}}();
+</script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <div class="container-12">
   <div class="grid-3 logo">
-    <h1 class="title"><a href="/"> <img class="logo" src="/images/logo-go-home_2014.png" alt="Go Open Source - Continuous Delivery"> </a></h1>
+    <h1 class="title"><a href="/" analytics-label="logo"> <img class="logo" src="/images/logo-go-home_2014.png" alt="Go Open Source - Continuous Delivery"> </a></h1>
     <ul class="social-icons social-icons-responsive">
       {% include social-icons.html %}
     </ul>
@@ -12,7 +12,7 @@
 
     <ul class="navigation">
       <div class="support-header">
-        <a target="_blank" class="icon-lifebuoy" href="https://www.thoughtworks.com/go/">Need Professional Support?</a>
+        <a target="_blank" class="icon-lifebuoy" href="https://www.thoughtworks.com/go/" analytics-label="professional support">Need Professional Support?</a>
       </div>
 
       {% for link in site.data.navigation %}
@@ -28,18 +28,18 @@
                     <ul class="second-level">
                       {% for secondlevel in firstlevel.second-level %}
                       <li>
-                        <a href="{{ secondlevel.url }}">{{ secondlevel.text }}</a>
+                        <a href="{{ secondlevel.url }}" analytics-label="{{ link.root }}>{{ firstlevel.text }}>{{ secondlevel.text }}" role="menuitem">{{ secondlevel.text }}</a>
                       </li>
                       {% endfor %}
                     </ul>
                   {% endif %}
-                  <a {% if firstlevel.target != undefined %} target="{{firstlevel.target}}" {% endif %} href="{{ firstlevel.url }}">{{ firstlevel.text }}{% if hasSecond %} <i class='icon-right-dir-2'></i>{% endif %}</a>
+                  <a {% if firstlevel.target != undefined %} target="{{firstlevel.target}}" {% endif %} href="{{ firstlevel.url }}" analytics-label="{{ link.root }}>{{ firstlevel.text }}" role="menuitem">{{ firstlevel.text }}{% if hasSecond %} <i class='icon-right-dir-2'></i>{% endif %}</a>
                 </li>
               {% endfor %}
             </ul>
-          <label class="{{link.icon}}">{{link.root}}{% if hasFirst %} <i class='icon-down-dir-2'></i>{% endif %}</label>
+          <label class="{{link.icon}}" analytics-label="{{ link.root }}" role="menuitem">{{link.root}}{% if hasFirst %} <i class='icon-down-dir-2'></i>{% endif %}</label>
         {% else %}
-            <a href="{{link.url}}" {% if link.target != undefined %} target="{{link.target}}" {% endif %} class="{{link.icon}}">{{link.root}}</a>
+            <a href="{{link.url}}" {% if link.target != undefined %} target="{{link.target}}" {% endif %} class="{{link.icon}}" analytics-label="{{link.root}}" role="menuitem">{{link.root}}</a>
         {% endif %}
         </li>
       {% endfor %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
 
     <ul class="navigation">
       <div class="support-header">
-        <a target="_blank" class="icon-lifebuoy" href="https://www.thoughtworks.com/go/" analytics-label="professional support">Need Professional Support?</a>
+        <a target="_blank" class="icon-lifebuoy" href="https://www.thoughtworks.com/go/" analytics-label="professional-support">Need Professional Support?</a>
       </div>
 
       {% for link in site.data.navigation %}

--- a/_includes/releaseAnnouncement.html
+++ b/_includes/releaseAnnouncement.html
@@ -1,6 +1,6 @@
 <div class="release-announce-holder">
 	<div class="container-12">
 		<h2>Go 16.1 now available!</h2>
-		Check out <a href="/releases/#latest">What's new</a> in 16.1 or <a href="/download/">Download</a> it.
+		Check out <a href="/releases/#latest">What's new</a> in 16.1 or <a href="/download/" analytics-label="release-announce-download">Download</a> it.
 	</div>
 </div>

--- a/_includes/social-icons.html
+++ b/_includes/social-icons.html
@@ -1,4 +1,4 @@
-<li><a target="_blank" title="Follow on Twitter" href="https://twitter.com/goforcd" class="icon-twitter"></a></li>
-<li><a target="_blank" title="GitHub Repository" href="https://github.com/gocd/gocd" class="icon-github-squared"></a></li>
-<li><a target="_blank" title="IRC Channel" href="http://webchat.freenode.net/?channels=gocd"><img width="27px" src="/images/irc_icon.png"></a></li>
-<li><a target="_blank" title="Google Group"  href="https://groups.google.com/forum/#!forum/go-cd" class="icon-google"></a></li>
+<li><a target="_blank" title="Follow on Twitter" href="https://twitter.com/goforcd" class="icon-twitter" analytics-label="twitter"></a></li>
+<li><a target="_blank" title="GitHub Repository" href="https://github.com/gocd/gocd" class="icon-github-squared" analytics-label="github"></a></li>
+<li><a target="_blank" title="IRC Channel" href="http://webchat.freenode.net/?channels=gocd" analytics-label="IRC"><img width="27px" src="/images/irc_icon.png"></a></li>
+<li><a target="_blank" title="Google Group"  href="https://groups.google.com/forum/#!forum/go-cd" class="icon-google" analytics-label="google-group"></a></li>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,7 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,300" rel="stylesheet" type="text/css">
 
     {{ page.extra_headers }}
-    
+
     <script type="text/javascript" src="/js/jquery-1.11.1.min.js"></script>
     <!--[if IE]>
           <script type="text/javascript" src="/js/xdr.js"></script>
@@ -39,14 +39,14 @@
 
     <!--[if lt IE 9]>
           <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
-      
+
           <script src="http://css3-mediaqueries-js.googlecode.com/svn/trunk/css3-mediaqueries.js"></script>
      <![endif]-->
 </head>
 
 <body class="{{ page.page_name }}">
     {% include google-tag-manager.html %}
-    <a href="https://github.com/gocd/gocd/">
+    <a href="https://github.com/gocd/gocd/" analytics-label="github-fork-me">
         <img class="fork-me-button" src="/images/fork-me-button.png" alt="Fork gocd on GitHub">
     </a>
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -32,7 +32,7 @@
 
         {% include google-tag-manager.html %}
 
-        <a href="https://github.com/gocd/gocd/">
+        <a href="https://github.com/gocd/gocd/" analytics-label="github-fork-me">
             <img class="fork-me-button" src="/images/fork-me-button.png" alt="Fork gocd on GitHub">
         </a>
 
@@ -55,7 +55,7 @@
         </div>
 
         <script type="text/javascript" src="/js/main.js"></script>
-        
+
         {% include analytics.html %}
 
     </body>

--- a/css/main.css
+++ b/css/main.css
@@ -818,7 +818,7 @@ body.blog {
     border-bottom: 1px solid #efefef;
 }
 
-.download-list .sha1, .download-list .md5{
+.download-list .checksums{
     margin-top: 10px;
     font-size: 0.7em;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -819,7 +819,6 @@ body.blog {
 }
 
 .download-list .sha1, .download-list .md5{
-    display: none;
     margin-top: 10px;
     font-size: 0.7em;
 }

--- a/download/index.html
+++ b/download/index.html
@@ -41,14 +41,14 @@ meta_tag_keywords: continuous deployment software, continuous integration tools,
                 </span>
                 <span style='float:right; width:150px;'>
                     Links
-                    <div><input id='show-checksum' type="checkbox" /> <label class="tiny" for='show-checksum'>Show Checksum</label></div>
+                    <div><input id='show-checksum' type="checkbox" analytics-label="show-checksum" checked="checked" /> <label class="tiny" for='show-checksum'>Show Checksum</label></div>
                 </span>
             </div>
         </th>
     </tr>
 </table>
 <ul class="nav nav-tabs os-select-holder" role="tablist">
-    <li><a href="#win" role="tab" data-toggle="tab"><i class='os__logo windows'></i>
+    <li><a href="#win" role="tab" data-toggle="tab" analytics-label="download-windows"><i class='os__logo windows'></i>
         <div class="os__text">
             <h5>Windows</h5>
             <span>.exe</span>
@@ -56,7 +56,7 @@ meta_tag_keywords: continuous deployment software, continuous integration tools,
         </a>
     </li>
     <li>
-        <a href="#mac" role="tab" data-toggle="tab"><i class='os__logo mac'></i>
+        <a href="#mac" role="tab" data-toggle="tab" analytics-label="download-mac"><i class='os__logo mac'></i>
         <div class="os__text">
             <h5>Mac OS X</h5>
             <span>.osx.zip</span>
@@ -64,24 +64,24 @@ meta_tag_keywords: continuous deployment software, continuous integration tools,
         </a>
     </li>
     <li>
-        <a href="#linux-deb" role="tab" data-toggle="tab"><i class='os__logo linux-deb'></i>
+        <a href="#linux-deb" role="tab" data-toggle="tab" analytics-label="download-linux-deb"><i class='os__logo linux-deb'></i>
         <div class="os__text">
             <h5>Linux <small style='font-size:0.6em'>(Debian, Ubuntu, ...)</small></h5>
             <span>.deb</span>
         </div>
         </a>
     </li>
-    <li><a href="#linux-rpm" role="tab" data-toggle="tab"><i class='os__logo linux-rpm'></i><div class="os__text">
+    <li><a href="#linux-rpm" role="tab" data-toggle="tab" analytics-label="download-linux-rpm"><i class='os__logo linux-rpm'></i><div class="os__text">
     <h5>Linux <small style='font-size:0.6em'>(Redhat, CentOS, ...)</small></h5>
     <span>.noarch.rpm</span>
 </div></a>
     </li>
-    <li><a href="#solaris" role="tab" data-toggle="tab"><i class='os__logo solaris'></i><div class="os__text">
+    <li><a href="#solaris" role="tab" data-toggle="tab" analytics-label="download-solaris"><i class='os__logo solaris'></i><div class="os__text">
     <h5>Solaris</h5>
     <span>.gz</span>
 </div></a>
     </li>
-    <li><a href="#zip" role="tab" data-toggle="tab"><i class='os__logo zip'></i><div class="os__text">
+    <li><a href="#zip" role="tab" data-toggle="tab" analytics-label="download-zip"><i class='os__logo zip'></i><div class="os__text">
     <h5>Package</h5>
     <span>.zip</span>
 </div></a>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ title: Go - Continuous Delivery software
 <hr>
 <div class="download-panel">
     <span style="display:inline-block">
-        <a href="/download/" class="download btn-big">
+        <a href="/download/" class="download btn-big" analytics-label="home-download-cta" role="button">
             <div> <i class="icon-download"></i> Download</div>
             <div class='smaller'>it's free!</div>
         </a>

--- a/js/download.js
+++ b/js/download.js
@@ -56,7 +56,7 @@ $(function() {
                 var linkSelector = '#' + GTMID(artifact, file).replace(/\./g, "\\.");
                 $(linkSelector).click(function() {
                     try {
-                        jtr.track(type + " download", {
+                        jtr.track(type.toLowerCase() + " download", {
                             download_release_type: artifact.release_type,
                             download_version: artifact.version,
                             download_file_type: file.type,

--- a/js/download.js
+++ b/js/download.js
@@ -9,9 +9,9 @@ $(function() {
         var input = $(evt.target);
 
         if (input.is(':checked')) {
-            $('.sha1, .md5').show();
+            $('.checksums').show();
         } else {
-            $('.sha1, .md5').hide();
+            $('.checksums').hide();
         }
     });
 
@@ -125,7 +125,7 @@ $(function() {
             _.each(filesWhichMatch, function(file, index, list) {
                 var type = downloadType(file);
                 if (!type) { return; }
-                revisionsString += '<div class="sha1">';
+                revisionsString += '<div class="checksums">';
                 revisionsString += "<div> <b>" + type + " MD5</b> " + file.md5sum + " </div>";
                 revisionsString += "<div> <b>" + type + " SHA1</b> " + file.sha1sum + "</div>";
                 revisionsString += '</div>';


### PR DESCRIPTION
This PR add anonymous visitor tracking for go.cd website using https://www.journey-app.io.

With usage data captured, we can potentially gain more understanding how user use the website and how they come. Thus provide us better information when we want to:  drive more traffic, increase adoption (downloads), or generally improve user experience of the website.

Current actions tracked in this PR are:
"open /foo page":  visitor open any pages;
"click foo>bar menuitem": visitor click menu items on the navigation header;
"agent download":  visitor download agent installer.
"server download":  visitor download server installer;
"click download-* tab":  visitor switching between different OS on download list page
"click github-fork-me button":   visitor click the "github fork me" stripe
"click professional-support link":  visitor click "Need Professional Support" link on the header
"click google-group link": visitor click google group link on the header;
"click home-download-cta button": visitor click call to action download button on home page
"click release-announce-download link": visitor click download link in release announcement;
"click logo link": visitor click GO logo on the header;
"click IRC link": visitor click freenode IRC link on the header
"click show-checksum checkbox": visitor toggle on/off show checksum on download page


